### PR TITLE
단축키 커스텀 훅 추가

### DIFF
--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+interface useShortcutProps {
+  onShortcutAction: () => void;
+  keys: string[];
+}
+
+const useShortcut = ({ onShortcutAction, keys }: useShortcutProps) => {
+  useEffect(() => {
+    const handler = (e) => {
+      const isPressed = keys?.every((key) => {
+        if (key === 'Alt') {
+          return e.altKey;
+        } else if (key === 'Control' || key === 'Ctrl') {
+          return e.ctrlKey;
+        } else if (key === 'Shift') {
+          return e.shiftKey;
+        } else if (key === 'Meta') {
+          return e.metaKey;
+        }
+        return e.key.toLowerCase() === key.toLowerCase();
+      });
+      if (isPressed) {
+        if (onShortcutAction) {
+          onShortcutAction();
+        }
+      }
+    };
+
+    if (window) {
+      document.addEventListener('keydown', handler);
+    }
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, [onShortcutAction, keys]);
+
+  return;
+};
+
+export default useShortcut;

--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -6,7 +6,7 @@ const useShortcut = (
   isGlobal: boolean
 ) => {
   useEffect(() => {
-    const handler = (e) => {
+    const handler = (e: KeyboardEvent) => {
       const isPressed = keys?.every((key) => {
         if (key === 'Alt') {
           return e.altKey;

--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -26,9 +26,7 @@ const useShortcut = ({
         return e.key.toLowerCase() === key.toLowerCase();
       });
       if (isPressed) {
-        if (onShortcutAction) {
-          onShortcutAction();
-        }
+        onShortcutAction();
       }
     };
     // 고민

--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -3,9 +3,14 @@ import { useEffect } from 'react';
 interface useShortcutProps {
   onShortcutAction: () => void;
   keys: string[];
+  isGlobal?: boolean;
 }
 
-const useShortcut = ({ onShortcutAction, keys }: useShortcutProps) => {
+const useShortcut = ({
+  onShortcutAction,
+  keys,
+  isGlobal,
+}: useShortcutProps) => {
   useEffect(() => {
     const handler = (e) => {
       const isPressed = keys?.every((key) => {
@@ -30,6 +35,10 @@ const useShortcut = ({ onShortcutAction, keys }: useShortcutProps) => {
     if (window) {
       document.addEventListener('keydown', handler);
     }
+    if (isGlobal) {
+      window.addEventListener('keydown', handler);
+    }
+
     return () => {
       document.removeEventListener('keydown', handler);
     };

--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -1,16 +1,10 @@
 import { useEffect } from 'react';
 
-interface useShortcutProps {
-  onShortcutAction: () => void;
-  keys: string[];
-  isGlobal?: boolean;
-}
-
-const useShortcut = ({
-  onShortcutAction,
-  keys,
-  isGlobal,
-}: useShortcutProps) => {
+const useShortcut = (
+  onShortcutAction: () => void,
+  keys: string[],
+  isGlobal: boolean
+) => {
   useEffect(() => {
     const handler = (e) => {
       const isPressed = keys?.every((key) => {

--- a/app/hooks/common/useShortcut.ts
+++ b/app/hooks/common/useShortcut.ts
@@ -31,18 +31,21 @@ const useShortcut = ({
         }
       }
     };
+    // 고민
+    // 다른 페이지로 먼저 접근하면 전역 이벤트가 설정되지 않는다.
+    // 생각나는 해결방법: layout.tsx 에서 useShortcut 훅을 사용하여 전역 이벤트를 설정한다.
+    // 이렇게 할 경우 어떤 페이지로 접근하든 전역 이벤트를 설정 할 수 있다.
 
-    if (window) {
-      document.addEventListener('keydown', handler);
-    }
     if (isGlobal) {
       window.addEventListener('keydown', handler);
+    } else if (window) {
+      document.addEventListener('keydown', handler);
     }
 
     return () => {
       document.removeEventListener('keydown', handler);
     };
-  }, [onShortcutAction, keys]);
+  }, [onShortcutAction, keys, isGlobal]);
 
   return;
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,11 @@ export default function Home() {
   };
 
   useShortcut({ onShortcutAction: goToWritePage, keys: ['Alt', 'N'] });
-  useShortcut({ onShortcutAction: goToPostsPage, keys: ['Ctrl', ';'] });
+  useShortcut({
+    onShortcutAction: goToPostsPage,
+    keys: ['Ctrl', ';'],
+    isGlobal: true,
+  });
 
   return (
     <main className="w-full max-w-4xl mx-auto grid gap-16 p-4 md:p-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,10 +16,13 @@ import useToast from '@/app/hooks/useToast';
 import useDataFetch from '@/app/hooks/common/useDataFetch';
 import { Post } from '@/app/types/Post';
 import ErrorBox from '@/app/entities/common/Error/ErrorBox';
+import { useRouter } from 'next/navigation';
+import useShortcut from '@/app/hooks/common/useShortcut';
 
 export default function Home() {
   const { fingerprint } = useFingerprint();
   const toast = useToast();
+  const router = useRouter();
 
   const fetchConfig = {
     method: 'GET' as const,
@@ -40,6 +43,13 @@ export default function Home() {
       toast.success('다시 오신 것을 환영합니다!');
     }
   }, [fingerprint]);
+
+  const goToWritePage = () => {
+    toast.success('글쓰기 페이지로 이동합니다...');
+    router.push('/admin/write');
+  };
+
+  useShortcut({ onShortcutAction: goToWritePage, keys: ['Alt', 'N'] });
 
   return (
     <main className="w-full max-w-4xl mx-auto grid gap-16 p-4 md:p-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,13 @@ export default function Home() {
     router.push('/admin/write');
   };
 
+  const goToPostsPage = () => {
+    toast.success('모든 글 목록 페이지로 이동합니다...');
+    router.push('/posts');
+  };
+
   useShortcut({ onShortcutAction: goToWritePage, keys: ['Alt', 'N'] });
+  useShortcut({ onShortcutAction: goToPostsPage, keys: ['Ctrl', ';'] });
 
   return (
     <main className="w-full max-w-4xl mx-auto grid gap-16 p-4 md:p-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,12 +54,8 @@ export default function Home() {
     router.push('/posts');
   };
 
-  useShortcut({ onShortcutAction: goToWritePage, keys: ['Alt', 'N'] });
-  useShortcut({
-    onShortcutAction: goToPostsPage,
-    keys: ['Ctrl', ';'],
-    isGlobal: true,
-  });
+  useShortcut(goToWritePage, ['Alt', 'N'], true);
+  useShortcut(goToPostsPage, ['Ctrl', ';'], true);
 
   return (
     <main className="w-full max-w-4xl mx-auto grid gap-16 p-4 md:p-8">


### PR DESCRIPTION
- 선언적으로 단축키에 대한 동작을 추가할 수 있는 커스텀 훅 구현
- 메인 페이지에서 글쓰기 페이지로 이동 등의 기능 구현
- `isGlobal` 변수로 전역으로 설정 가능하도록 구현
<img width="461" height="57" alt="image" src="https://github.com/user-attachments/assets/b7c55154-a880-46cf-a6d5-1c5a528b40ee" />

고민: 
// 다른 페이지로 먼저 접근하면 전역 이벤트가 설정되지 않는다.
// 생각나는 해결방법: layout.tsx 에서 useShortcut 훅을 사용하여 전역 이벤트를 설정한다.
// 이렇게 할 경우 어떤 페이지로 접근하든 전역 이벤트를 설정 할 수 있다.
