### PR TITLE
refactor: Atelier 채팅 UI/UX 개선 및 컴포넌트 리팩토링

### DIFF
--- a/app/api/atelier/messages/[id]/reaction/route.ts
+++ b/app/api/atelier/messages/[id]/reaction/route.ts
@@ -51,7 +51,12 @@ export const POST = async (request: Request, { params }: RouteParams) => {
         { status: 400 }
       );
     }
-    const { emoji } = body as { emoji: string };
+    const { emoji, nickname, avatarUrl, githubId } = body as {
+      emoji: string;
+      nickname?: string;
+      avatarUrl?: string;
+      githubId?: string;
+    };
     if (!allowedEmojiSet.has(emoji)) {
       return Response.json(
         { success: false, error: '허용되지 않은 이모지입니다.' },
@@ -69,20 +74,34 @@ export const POST = async (request: Request, { params }: RouteParams) => {
     }
 
     // 해당 이모지 버킷 찾기
+    interface ReactorDoc {
+      fingerprint: string;
+      nickname: string;
+      avatarUrl?: string;
+      githubId?: string;
+    }
     interface ReactionDoc {
       emoji: string;
       fingerprints: string[];
       count: number;
+      reactors: ReactorDoc[];
     }
     const reactions = message.reactions as unknown as ReactionDoc[];
     const bucketIndex = reactions.findIndex((r) => r.emoji === emoji);
 
+    const reactorInfo: ReactorDoc = {
+      fingerprint,
+      nickname: nickname ?? '익명',
+      ...(avatarUrl && { avatarUrl }),
+      ...(githubId && { githubId }),
+    };
+
     if (bucketIndex === -1) {
-      // 새 버킷 추가
       reactions.push({
         emoji,
         fingerprints: [fingerprint],
         count: 1,
+        reactors: [reactorInfo],
       });
     } else {
       const bucket = reactions[bucketIndex];
@@ -90,6 +109,7 @@ export const POST = async (request: Request, { params }: RouteParams) => {
       if (fpIndex >= 0) {
         // 이미 눌렀음 → 해제
         bucket.fingerprints.splice(fpIndex, 1);
+        bucket.reactors = bucket.reactors.filter((r) => r.fingerprint !== fingerprint);
         bucket.count = bucket.fingerprints.length;
         if (bucket.count === 0) {
           reactions.splice(bucketIndex, 1);
@@ -97,6 +117,7 @@ export const POST = async (request: Request, { params }: RouteParams) => {
       } else {
         // 새로 추가
         bucket.fingerprints.push(fingerprint);
+        bucket.reactors.push(reactorInfo);
         bucket.count = bucket.fingerprints.length;
       }
     }
@@ -104,13 +125,21 @@ export const POST = async (request: Request, { params }: RouteParams) => {
     message.markModified('reactions');
     await message.save();
 
-    // 응답 시 fingerprints 제거, hasReacted 계산
+    // 응답 시 fingerprints 제거, hasReacted + reactors 계산
+    let anonCounter = 0;
     const responseReactions: ReactionBucket[] = (
       message.reactions as unknown as ReactionDoc[]
     ).map((r) => ({
       emoji: r.emoji,
       count: r.count,
       hasReacted: r.fingerprints.includes(fingerprint),
+      reactors: r.reactors.map((reactor) => {
+        if (reactor.githubId) {
+          return { displayName: reactor.nickname, avatarUrl: reactor.avatarUrl };
+        }
+        anonCounter += 1;
+        return { displayName: `익명${anonCounter}` };
+      }),
     }));
 
     return Response.json(

--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -32,6 +32,8 @@ const AtelierPage = () => {
     removeOptimistic,
     updateMessage,
     removeMessage,
+    getSnapshot,
+    restoreMessage,
   } = useAtelierMessages({ limit: 30 });
 
   const mutations = useAtelierMutations({
@@ -48,6 +50,8 @@ const AtelierPage = () => {
       removeOptimistic,
       updateMessage,
       removeMessage,
+      getSnapshot,
+      restoreMessage,
     },
   });
 

--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -172,7 +172,7 @@ const AtelierPage = () => {
 
           {/* 입력 */}
           <div className="shrink-0">
-            <MessageInput onSend={handleSendRoot} placeholder={placeholder} />
+            <MessageInput onSend={handleSendRoot} placeholder={placeholder} isAdmin={author.isAdmin} />
           </div>
 
           {/* 닉네임 게이트 (익명 방문자 전용) */}

--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -131,23 +131,31 @@ const AtelierPage = () => {
       <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-[calc(100dvh-4rem)] flex flex-col gap-4 py-4">
         <div className="flex flex-col gap-4 flex-1 min-h-0 animate-atelierIn duration-1000">
           {/* 헤더 */}
-          <div className="shrink-0">
-            <h1
-              className={`${cormorant.className} text-[clamp(2rem,8vw,3.5rem)] font-light italic tracking-wide relative inline-block`}
-            >
-              Atelier
-              <Image
-                src="/images/atelier/pen.png"
-                alt="pen"
-                width={1024}
-                height={1024}
-                priority
-                className="absolute -right-[clamp(3rem,8vw,6.5rem)] top-1/3 -translate-y-2/4 rotate-[10deg] w-[clamp(4rem,10vw,8rem)] h-[clamp(4rem,10vw,8rem)] -z-10 opacity-90 dark:invert"
+          <div className="shrink-0 flex justify-between items-end">
+            <div>
+              <h1
+                className={`${cormorant.className} text-[clamp(2rem,8vw,3.5rem)] font-light italic tracking-wide relative inline-block`}
+              >
+                Atelier
+                <Image
+                  src="/images/atelier/pen.png"
+                  alt="pen"
+                  width={1024}
+                  height={1024}
+                  priority
+                  className="absolute -right-[clamp(3rem,8vw,6.5rem)] top-1/3 -translate-y-2/4 rotate-[10deg] w-[clamp(4rem,10vw,8rem)] h-[clamp(4rem,10vw,8rem)] -z-10 opacity-90 dark:invert"
+                />
+              </h1>
+              <p className="text-sm text-weak mt-1 tracking-widest uppercase">
+                생각들을 던져두는 곳
+              </p>
+            </div>
+            {/* 이전 메시지 로딩 스피너 — 공간 유지하며 숨김/표시 */}
+            <div className={`pb-1 ${hasMore ? '' : 'hidden'}`}>
+              <div
+                className={`w-3 h-3 rounded-full border-2 border-border border-t-weak transition-opacity duration-200 ${isLoadingOlder ? 'opacity-100 animate-spin' : 'opacity-0'}`}
               />
-            </h1>
-            <p className="text-sm text-weak mt-1 tracking-widest uppercase">
-              생각들을 던져두는 곳
-            </p>
+            </div>
           </div>
 
           {/* 채팅 피드 */}

--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -2,6 +2,7 @@
 import { Cormorant_Garamond } from 'next/font/google';
 import Image from 'next/image';
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import ChatFeed from '@/app/entities/atelier/ChatFeed';
 import MessageInput from '@/app/entities/atelier/MessageInput';
 import NicknameGate from '@/app/entities/atelier/NicknameGate';
@@ -188,12 +189,14 @@ const AtelierPage = () => {
           </div>
 
           {/* 닉네임 게이트 (익명 방문자 전용) */}
-          {isGateOpen && (
-            <NicknameGate
-              onSubmit={handleSubmitNickname}
-              onClose={handleCloseGate}
-            />
-          )}
+          {isGateOpen &&
+            createPortal(
+              <NicknameGate
+                onSubmit={handleSubmitNickname}
+                onClose={handleCloseGate}
+              />,
+              document.body
+            )}
         </div>
       </section>
     </>

--- a/app/entities/atelier/ChatFeed.tsx
+++ b/app/entities/atelier/ChatFeed.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import ChatFeedSkeleton from '@/app/entities/atelier/ChatFeedSkeleton';
 import MessageBubble from '@/app/entities/atelier/MessageBubble';
 import { AtelierEmoji, AtelierMessage } from '@/app/types/Atelier';
@@ -70,59 +70,32 @@ const ChatFeed = ({
 }: ChatFeedProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
-
-  // prepend 전 스크롤 높이 저장 (loadOlder 요청 시점에 세팅)
-  const savedScrollHeightRef = useRef<number | null>(null);
-  // 최초 마운트 여부 — 첫 렌더 때만 bottom 으로 스크롤
-  const hasScrolledToBottomRef = useRef(false);
   // 최신 메시지 수 추적 (새 메시지 도착 시 하단 유지용)
   const prevMessageCountRef = useRef(0);
+  // isLoadingOlder를 ref로 추적 — observer effect dependency에서 제거해 재구독 루프 방지
+  const isLoadingOlderRef = useRef(isLoadingOlder);
+  useEffect(() => {
+    isLoadingOlderRef.current = isLoadingOlder;
+  }, [isLoadingOlder]);
 
-  // 초기 로드 시 하단으로 스크롤 — 페인트 전에 실행해 플래시 방지
-  useLayoutEffect(() => {
-    if (isInitialLoading) return;
-    if (hasScrolledToBottomRef.current) return;
-    if (!containerRef.current) return;
-    if (messages.length === 0) return;
-    containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    hasScrolledToBottomRef.current = true;
-    prevMessageCountRef.current = messages.length;
-  }, [isInitialLoading, messages.length]);
-
-  // prepend 시 스크롤 보정 (scrollHeight delta 만큼 내려서 위치 유지)
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    if (savedScrollHeightRef.current == null) return;
-    const delta = container.scrollHeight - savedScrollHeightRef.current;
-    if (delta > 0) {
-      container.scrollTop = container.scrollTop + delta;
-    }
-    savedScrollHeightRef.current = null;
-  }, [messages]);
-
-  // 새 메시지가 하단에 추가되면 자동 스크롤 (위쪽 prepend 는 제외)
+  // 새 메시지가 추가되면 자동 스크롤 (flex-col-reverse: scrollTop=0이 시각적 맨 아래)
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    if (!hasScrolledToBottomRef.current) return;
-    if (savedScrollHeightRef.current != null) return;
 
     const prev = prevMessageCountRef.current;
     const next = messages.length;
     if (next > prev) {
-      // 사용자가 거의 하단에 있을 때만 자동 스크롤
       const threshold = 120;
-      const distanceFromBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight;
-      if (distanceFromBottom < threshold) {
-        container.scrollTop = container.scrollHeight;
+      if (container.scrollTop < threshold) {
+        container.scrollTop = 0;
       }
     }
     prevMessageCountRef.current = next;
   }, [messages]);
 
-  // IntersectionObserver — 상단 sentinel 이 보이면 loadOlder 호출
+  // IntersectionObserver — sentinel이 보이면 loadOlder 호출
+  // isLoadingOlder는 ref로 읽어 observer 재구독 루프를 방지
   useEffect(() => {
     const sentinel = sentinelRef.current;
     const container = containerRef.current;
@@ -132,9 +105,7 @@ const ChatFeed = ({
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry.isIntersecting) return;
-        if (isLoadingOlder) return;
-        // prepend 전 scrollHeight 저장
-        savedScrollHeightRef.current = container.scrollHeight;
+        if (isLoadingOlderRef.current) return;
         onLoadOlder();
       },
       { root: container, threshold: 0.1 }
@@ -142,29 +113,28 @@ const ChatFeed = ({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [hasMore, isLoadingOlder, onLoadOlder]);
+  }, [hasMore, onLoadOlder]);
 
   if (isInitialLoading) return <ChatFeedSkeleton />;
 
   return (
+    // flex-col-reverse + overflow-y-auto: scrollTop=0이 시각적 맨 아래 (Discord/Slack 방식)
     <div
       ref={containerRef}
-      className="flex flex-col h-full overflow-y-auto border border-border rounded-2xl p-4 scroll-smooth"
+      className="relative flex flex-col-reverse h-full overflow-y-auto border border-border rounded-2xl p-4"
     >
-      {/* 상단 sentinel — infinite scroll 트리거 */}
+      {/* 시각적 맨 위 sentinel — DOM 끝 = flex-col-reverse로 시각적 맨 위 */}
       <div ref={sentinelRef} className="h-1" />
 
-      {hasMore && isLoadingOlder && (
-        <p className="text-center text-xs text-weak">이전 메시지 불러오는 중...</p>
-      )}
 
       {messages.length === 0 ? (
-        <div className="flex items-center justify-center h-full">
+        <div className="flex items-center justify-center py-8">
           <p className="text-weak text-sm">아직 아무것도 없어요</p>
         </div>
       ) : (
         messages
           .filter((m) => m.parentId === null)
+          .reverse()
           .map((message, idx, arr) => {
             const isMine = computeIsMine(
               message,
@@ -172,24 +142,25 @@ const ChatFeed = ({
               currentFingerprint,
               currentGithubId
             );
-            const prev = arr[idx - 1];
-            const next = arr[idx + 1];
-            const groupedWithPrev =
-              !!prev &&
-              isSameAuthor(prev, message) &&
-              isWithinOneMinute(prev, message);
-            const groupedWithNext =
-              !!next &&
-              isSameAuthor(message, next) &&
-              isWithinOneMinute(message, next);
+            // reverse 배열: arr[idx+1]이 시각적 위(더 오래된), arr[idx-1]이 시각적 아래(더 최신)
+            const olderNeighbor = arr[idx + 1];
+            const newerNeighbor = arr[idx - 1];
+            const groupedWithOlder =
+              !!olderNeighbor &&
+              isSameAuthor(message, olderNeighbor) &&
+              isWithinOneMinute(message, olderNeighbor);
+            const groupedWithNewer =
+              !!newerNeighbor &&
+              isSameAuthor(message, newerNeighbor) &&
+              isWithinOneMinute(message, newerNeighbor);
             return (
               <MessageBubble
                 key={message._id}
                 message={message}
                 isMine={isMine}
                 isAdmin={isAdmin}
-                showAuthor={!groupedWithPrev}
-                showTime={!groupedWithNext}
+                showAuthor={!groupedWithOlder}
+                showTime={!groupedWithNewer}
                 currentFingerprint={currentFingerprint}
                 currentGithubId={currentGithubId}
                 onReact={onReact}

--- a/app/entities/atelier/MessageActions.tsx
+++ b/app/entities/atelier/MessageActions.tsx
@@ -1,8 +1,6 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import EmojiPicker from '@/app/entities/atelier/EmojiPicker';
-import { AtelierEmoji, AtelierMessage } from '@/app/types/Atelier';
+import { useState } from 'react';
+import { ATELIER_EMOJIS, AtelierEmoji, AtelierMessage } from '@/app/types/Atelier';
 
 interface MessageActionsProps {
   message: AtelierMessage;
@@ -14,9 +12,9 @@ interface MessageActionsProps {
   onDelete: () => void;
   onTogglePublic: () => void;
   onBlock: () => void;
+  onPickerChange?: (open: boolean) => void;
 }
 
-// 메시지 버블 호버/롱프레스 시 노출되는 액션 바
 const MessageActions = ({
   message,
   isAdmin,
@@ -27,115 +25,106 @@ const MessageActions = ({
   onDelete,
   onTogglePublic,
   onBlock,
+  onPickerChange,
 }: MessageActionsProps) => {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
-  const [pickerPos, setPickerPos] = useState({ top: 0, left: 0 });
-  const emojiButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (!isPickerOpen || !emojiButtonRef.current) return;
-    const rect = emojiButtonRef.current.getBoundingClientRect();
-    setPickerPos({ top: rect.top - 8, left: rect.left });
-  }, [isPickerOpen]);
+  const openPicker = () => {
+    setIsPickerOpen(true);
+    onPickerChange?.(true);
+  };
 
-  const handleToggleReact = () => {
-    setIsPickerOpen((prev) => !prev);
+  const closePicker = () => {
+    setIsPickerOpen(false);
+    onPickerChange?.(false);
   };
 
   const handleSelectEmoji = (emoji: AtelierEmoji) => {
     onReact(emoji);
-  };
-
-  const handleClosePicker = () => {
-    setIsPickerOpen(false);
-  };
-
-  const handleReply = () => {
-    onReply();
-  };
-
-  const handleDelete = () => {
-    onDelete();
-  };
-
-  const handleTogglePublic = () => {
-    onTogglePublic();
-  };
-
-  const handleBlock = () => {
-    onBlock();
-  };
-
-  const handleEdit = () => {
-    onEdit();
+    closePicker();
   };
 
   return (
     <div className="relative inline-flex items-center gap-1 whitespace-nowrap bg-white/70 dark:bg-neutral-900/70 backdrop-blur-md border border-border rounded-full px-2 py-1 shadow-sm">
-      {isPickerOpen && createPortal(
-        <div
-          className="fixed z-[100]"
-          style={{ top: pickerPos.top, left: pickerPos.left, transform: 'translateY(-100%)' }}
-        >
-          <EmojiPicker onSelect={handleSelectEmoji} onClose={handleClosePicker} />
-        </div>,
-        document.body
-      )}
-
-      <button
-        ref={emojiButtonRef}
-        type="button"
-        onClick={handleToggleReact}
-        className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
-        aria-label="반응 추가"
-      >
-        😊
-      </button>
-      <button
-        type="button"
-        onClick={handleReply}
-        className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
-      >
-        답글
-      </button>
-
-      {isMine && (
-        <button
-          type="button"
-          onClick={handleEdit}
-          className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
-        >
-          수정
-        </button>
-      )}
-
-      {(isAdmin || isMine) && (
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="text-xs text-weak hover:text-red-500 transition-colors px-1.5 py-0.5 rounded"
-        >
-          삭제
-        </button>
-      )}
-
-      {isAdmin && (
+      {isPickerOpen ? (
+        <>
+          {ATELIER_EMOJIS.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => handleSelectEmoji(emoji)}
+              className="text-lg leading-none px-1.5 py-0.5 rounded-full hover:bg-brand-primary/10 transition-colors"
+              aria-label={`${emoji} 반응 추가`}
+            >
+              {emoji}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={closePicker}
+            className="text-xs text-weak hover:text-foreground transition-colors px-1.5 py-0.5 rounded ml-0.5"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </>
+      ) : (
         <>
           <button
             type="button"
-            onClick={handleTogglePublic}
+            onClick={openPicker}
+            className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
+            aria-label="반응 추가"
+          >
+            😊
+          </button>
+          <button
+            type="button"
+            onClick={onReply}
             className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
           >
-            {message.isPublic ? '비공개' : '공개'}
+            답글
           </button>
-          {message.author.fingerprint && (
+
+          {isMine && (
             <button
               type="button"
-              onClick={handleBlock}
+              onClick={onEdit}
+              className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
+            >
+              수정
+            </button>
+          )}
+
+          {(isAdmin || isMine) && (
+            <button
+              type="button"
+              onClick={onDelete}
               className="text-xs text-weak hover:text-red-500 transition-colors px-1.5 py-0.5 rounded"
             >
-              차단
+              삭제
             </button>
+          )}
+
+          {isAdmin && (
+            <>
+              <button
+                type="button"
+                onClick={onTogglePublic}
+                className="text-xs text-weak hover:text-brand-primary transition-colors px-1.5 py-0.5 rounded"
+              >
+                {message.isPublic ? '비공개' : '공개'}
+              </button>
+              {message.author.fingerprint && (
+                <button
+                  type="button"
+                  onClick={onBlock}
+                  className="text-xs text-weak hover:text-red-500 transition-colors px-1.5 py-0.5 rounded"
+                >
+                  차단
+                </button>
+              )}
+            </>
           )}
         </>
       )}

--- a/app/entities/atelier/MessageBubble.tsx
+++ b/app/entities/atelier/MessageBubble.tsx
@@ -62,6 +62,7 @@ const MessageBubble = ({
 }: MessageBubbleProps) => {
   const [isThreadOpen, setIsThreadOpen] = useState(false);
   const [isActionsVisible, setIsActionsVisible] = useState(false);
+  const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
   const [entered, setEntered] = useState(() => skipEntryAnimSet.has(message._id));
@@ -69,7 +70,9 @@ const MessageBubble = ({
   const [editContent, setEditContent] = useState(message.content);
 
   const handleMouseEnter = () => setIsActionsVisible(true);
-  const handleMouseLeave = () => setIsActionsVisible(false);
+  const handleMouseLeave = () => {
+    if (!isEmojiPickerOpen) setIsActionsVisible(false);
+  };
 
   const handleReact = (emoji: AtelierEmoji) => {
     onReact(message._id, emoji);
@@ -241,6 +244,7 @@ const MessageBubble = ({
               onDelete={handleDelete}
               onTogglePublic={handleTogglePublic}
               onBlock={handleBlock}
+              onPickerChange={setIsEmojiPickerOpen}
             />
           </div>
         )}

--- a/app/entities/atelier/MessageBubble.tsx
+++ b/app/entities/atelier/MessageBubble.tsx
@@ -216,6 +216,12 @@ const MessageBubble = ({
                 fontSize: 'inherit',
               }}
               wrapperElement={{ 'data-color-mode': isOwner ? 'dark' : 'light' }}
+              components={{
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                a: ({ node, ...props }) => (
+                  <a {...props} target="_blank" rel="noopener noreferrer" />
+                ),
+              }}
             />
           )}
         </div>

--- a/app/entities/atelier/MessageBubble.tsx
+++ b/app/entities/atelier/MessageBubble.tsx
@@ -248,9 +248,9 @@ const MessageBubble = ({
         </button>
       )}
 
-      {showTime && (
+      {(showTime || message.isEdited) && (
         <span className="text-xs text-weak px-1">
-          {formatTime(message.createdAt)}
+          {showTime && formatTime(message.createdAt)}
           {message.isEdited && (
             <span className="text-[10px] text-weak italic ml-1">(수정됨)</span>
           )}

--- a/app/entities/atelier/MessageBubble.tsx
+++ b/app/entities/atelier/MessageBubble.tsx
@@ -10,6 +10,9 @@ import DeleteModal from '@/app/entities/common/Modal/DeleteModal';
 import { AtelierEmoji, AtelierMessage } from '@/app/types/Atelier';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 
+// optimistic → real 교체 시 재마운트되는 컴포넌트가 입장 애니메이션을 건너뛰도록
+export const skipEntryAnimSet = new Set<string>();
+
 interface MessageBubbleProps {
   message: AtelierMessage;
   isMine: boolean;
@@ -60,6 +63,8 @@ const MessageBubble = ({
   const [isThreadOpen, setIsThreadOpen] = useState(false);
   const [isActionsVisible, setIsActionsVisible] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [entered, setEntered] = useState(() => skipEntryAnimSet.has(message._id));
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(message.content);
 
@@ -80,7 +85,7 @@ const MessageBubble = ({
 
   const handleConfirmDelete = () => {
     setIsDeleteModalOpen(false);
-    onDelete(message._id);
+    setIsRemoving(true);
   };
 
   const handleTogglePublic = () => {
@@ -123,7 +128,7 @@ const MessageBubble = ({
 
   // 버블 정렬 방향
   const alignCls = isMine ? 'items-end' : 'items-start';
-  const animCls = isMine ? 'animate-bubbleInRight' : 'animate-bubbleInLeft';
+  const entryAnimCls = entered ? '' : (isMine ? 'animate-bubbleInRight' : 'animate-bubbleInLeft');
 
   // 버블 자체 스타일 — 소유자 여부에 따라 색을 분리
   const bubbleCls = isOwner
@@ -131,7 +136,13 @@ const MessageBubble = ({
     : 'rounded-2xl rounded-tl-sm bg-white/60 dark:bg-neutral-800/60 backdrop-blur-sm text-foreground border border-border shadow-sm';
 
   return (
-    <div className={`flex flex-col gap-1 ${alignCls} ${animCls} ${showAuthor ? 'mt-4 first:mt-0' : 'mt-1'}`}>
+    <div
+      className={`flex flex-col gap-1 ${alignCls} ${isRemoving ? `animate-bubblePop pointer-events-none ${isMine ? 'origin-right' : 'origin-left'}` : entryAnimCls} ${showAuthor ? 'mt-4 first:mt-0' : 'mt-1'}`}
+      onAnimationEnd={(e) => {
+        if (isRemoving) { onDelete(message._id); return; }
+        if (e.currentTarget === e.target) setEntered(true);
+      }}
+    >
       {/* 작성자 정보 (내 메시지가 아니고 묶음 첫 메시지일 때 노출) */}
       {!isMine && showAuthor && (
         <div className="flex items-center gap-1.5 px-1 ml-1">

--- a/app/entities/atelier/MessageInput.tsx
+++ b/app/entities/atelier/MessageInput.tsx
@@ -1,6 +1,6 @@
 'use client';
-import MarkdownPreview from '@uiw/react-markdown-preview';
 import { KeyboardEvent, useRef, useState } from 'react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
 
 const GUEST_MAX_LENGTH = 200;
 

--- a/app/entities/atelier/MessageInput.tsx
+++ b/app/entities/atelier/MessageInput.tsx
@@ -63,38 +63,35 @@ const MessageInput = ({
   };
 
   return (
-    <div className="flex flex-col gap-1">
-      <div className="flex gap-2 items-stretch">
-        <textarea
-          ref={textareaRef}
-          value={input}
-          onChange={handleChange}
-          onCompositionStart={handleCompositionStart}
-          onCompositionEnd={handleCompositionEnd}
-          onKeyDown={handleKeyDown}
-          disabled={disabled}
-          className="flex-1 resize-none rounded-xl border border-border bg-transparent p-3 text-sm outline-none focus:ring-1 focus:ring-brand-primary transition-all disabled:opacity-50"
-          rows={2}
-          placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
-        />
-        <button
-          type="button"
-          onClick={handleClickSend}
-          disabled={!input.trim() || disabled || isSending || isOverLimit}
-          className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
-        >
-          {isSending ? (
-            <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
-          ) : (
-            '전송'
-          )}
-        </button>
-      </div>
-      {maxLength !== undefined && input.length > 0 && (
-        <p className={`text-xs text-right pr-1 ${isOverLimit ? 'text-red-500' : 'text-weak'}`}>
-          {input.length} / {maxLength}
-        </p>
-      )}
+    <div className="flex gap-2 items-stretch">
+      <textarea
+        ref={textareaRef}
+        value={input}
+        onChange={handleChange}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={`flex-1 resize-none rounded-xl border bg-transparent p-3 text-sm outline-none focus:ring-1 transition-all disabled:opacity-50 ${
+          isOverLimit
+            ? 'border-red-500 focus:ring-red-500'
+            : 'border-border focus:ring-brand-primary'
+        }`}
+        rows={2}
+        placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
+      />
+      <button
+        type="button"
+        onClick={handleClickSend}
+        disabled={!input.trim() || disabled || isSending || isOverLimit}
+        className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
+      >
+        {isSending ? (
+          <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+        ) : (
+          '전송'
+        )}
+      </button>
     </div>
   );
 };

--- a/app/entities/atelier/MessageInput.tsx
+++ b/app/entities/atelier/MessageInput.tsx
@@ -1,10 +1,13 @@
 'use client';
 import { KeyboardEvent, useRef, useState } from 'react';
 
+const GUEST_MAX_LENGTH = 200;
+
 interface MessageInputProps {
   onSend: (content: string) => void | boolean | Promise<void | boolean>;
   placeholder?: string;
   disabled?: boolean;
+  isAdmin?: boolean;
 }
 
 // 하단 입력 바 — IME 조합 중엔 전송 안함, Enter 전송, Shift+Enter 줄바꿈
@@ -12,7 +15,9 @@ const MessageInput = ({
   onSend,
   placeholder,
   disabled = false,
+  isAdmin = false,
 }: MessageInputProps) => {
+  const maxLength = isAdmin ? undefined : GUEST_MAX_LENGTH;
   const [input, setInput] = useState('');
   const [isSending, setIsSending] = useState(false);
   const isComposing = useRef(false);
@@ -30,9 +35,11 @@ const MessageInput = ({
     isComposing.current = false;
   };
 
+  const isOverLimit = maxLength !== undefined && input.length > maxLength;
+
   const handleSend = async () => {
     const trimmed = input.trim();
-    if (!trimmed || disabled || isSending) return;
+    if (!trimmed || disabled || isSending || isOverLimit) return;
     setIsSending(true);
     try {
       const result = await onSend(trimmed);
@@ -56,31 +63,38 @@ const MessageInput = ({
   };
 
   return (
-    <div className="flex gap-2 items-stretch">
-      <textarea
-        ref={textareaRef}
-        value={input}
-        onChange={handleChange}
-        onCompositionStart={handleCompositionStart}
-        onCompositionEnd={handleCompositionEnd}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        className="flex-1 resize-none rounded-xl border border-border bg-transparent p-3 text-sm outline-none focus:ring-1 focus:ring-brand-primary transition-all disabled:opacity-50"
-        rows={2}
-        placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
-      />
-      <button
-        type="button"
-        onClick={handleClickSend}
-        disabled={!input.trim() || disabled || isSending}
-        className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
-      >
-        {isSending ? (
-          <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
-        ) : (
-          '전송'
-        )}
-      </button>
+    <div className="flex flex-col gap-1">
+      <div className="flex gap-2 items-stretch">
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={handleChange}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          className="flex-1 resize-none rounded-xl border border-border bg-transparent p-3 text-sm outline-none focus:ring-1 focus:ring-brand-primary transition-all disabled:opacity-50"
+          rows={2}
+          placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
+        />
+        <button
+          type="button"
+          onClick={handleClickSend}
+          disabled={!input.trim() || disabled || isSending || isOverLimit}
+          className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
+        >
+          {isSending ? (
+            <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+          ) : (
+            '전송'
+          )}
+        </button>
+      </div>
+      {maxLength !== undefined && input.length > 0 && (
+        <p className={`text-xs text-right pr-1 ${isOverLimit ? 'text-red-500' : 'text-weak'}`}>
+          {input.length} / {maxLength}
+        </p>
+      )}
     </div>
   );
 };

--- a/app/entities/atelier/MessageInput.tsx
+++ b/app/entities/atelier/MessageInput.tsx
@@ -1,4 +1,5 @@
 'use client';
+import MarkdownPreview from '@uiw/react-markdown-preview';
 import { KeyboardEvent, useRef, useState } from 'react';
 
 const GUEST_MAX_LENGTH = 200;
@@ -20,6 +21,7 @@ const MessageInput = ({
   const maxLength = isAdmin ? undefined : GUEST_MAX_LENGTH;
   const [input, setInput] = useState('');
   const [isSending, setIsSending] = useState(false);
+  const [isPreviewing, setIsPreviewing] = useState(false);
   const isComposing = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -45,6 +47,7 @@ const MessageInput = ({
       const result = await onSend(trimmed);
       if (result === false) return;
       setInput('');
+      setIsPreviewing(false);
       textareaRef.current?.focus();
     } finally {
       setIsSending(false);
@@ -58,40 +61,86 @@ const MessageInput = ({
     }
   };
 
-  const handleClickSend = () => {
-    handleSend();
+  const handleTabClick = (preview: boolean) => {
+    setIsPreviewing(preview);
+    if (!preview) {
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    }
   };
 
   return (
-    <div className="flex gap-2 items-stretch">
-      <textarea
-        ref={textareaRef}
-        value={input}
-        onChange={handleChange}
-        onCompositionStart={handleCompositionStart}
-        onCompositionEnd={handleCompositionEnd}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        className={`flex-1 resize-none rounded-xl border bg-transparent p-3 text-sm outline-none focus:ring-1 transition-all disabled:opacity-50 ${
-          isOverLimit
-            ? 'border-red-500 focus:ring-red-500'
-            : 'border-border focus:ring-brand-primary'
-        }`}
-        rows={2}
-        placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
-      />
-      <button
-        type="button"
-        onClick={handleClickSend}
-        disabled={!input.trim() || disabled || isSending || isOverLimit}
-        className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
-      >
-        {isSending ? (
-          <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+    <div className="flex flex-col gap-1">
+      {/* 탭 */}
+      <div className="flex gap-1">
+        <button
+          type="button"
+          onClick={() => handleTabClick(false)}
+          className={`px-3 py-1 text-xs rounded-lg transition-colors ${
+            !isPreviewing
+              ? 'bg-brand-primary text-white'
+              : 'text-weak hover:text-foreground'
+          }`}
+        >
+          작성
+        </button>
+        <button
+          type="button"
+          onClick={() => handleTabClick(true)}
+          className={`px-3 py-1 text-xs rounded-lg transition-colors ${
+            isPreviewing
+              ? 'bg-brand-primary text-white'
+              : 'text-weak hover:text-foreground'
+          }`}
+        >
+          미리보기
+        </button>
+      </div>
+
+      {/* 입력 영역 + 전송 버튼 */}
+      <div className="flex gap-2 items-stretch">
+        {isPreviewing ? (
+          <div className="flex-1 min-h-[4.75rem] rounded-xl border border-border p-3 text-sm overflow-y-auto">
+            {input.trim() ? (
+              <MarkdownPreview
+                source={input}
+                style={{ background: 'transparent', color: 'inherit', fontSize: 'inherit' }}
+                wrapperElement={{ 'data-color-mode': isAdmin ? 'dark' : 'light' }}
+              />
+            ) : (
+              <span className="text-weak">내용이 없어요</span>
+            )}
+          </div>
         ) : (
-          '전송'
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={handleChange}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            onKeyDown={handleKeyDown}
+            disabled={disabled}
+            className={`flex-1 resize-none rounded-xl border bg-transparent p-3 text-sm outline-none focus:ring-1 transition-all disabled:opacity-50 ${
+              isOverLimit
+                ? 'border-red-500 focus:ring-red-500'
+                : 'border-border focus:ring-brand-primary'
+            }`}
+            rows={2}
+            placeholder={placeholder ?? '생각을 던져보세요... (Enter)'}
+          />
         )}
-      </button>
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={!input.trim() || disabled || isSending || isOverLimit}
+          className="px-4 rounded-xl bg-brand-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-30 transition-opacity"
+        >
+          {isSending ? (
+            <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+          ) : (
+            '전송'
+          )}
+        </button>
+      </div>
     </div>
   );
 };

--- a/app/entities/atelier/NicknameGate.tsx
+++ b/app/entities/atelier/NicknameGate.tsx
@@ -1,32 +1,31 @@
 'use client';
 import { signIn } from 'next-auth/react';
-import { FormEvent, useState } from 'react';
 import { FaGithub } from 'react-icons/fa6';
 
 interface NicknameGateProps {
-  onSubmit: (nickname: string) => void;
+  onSubmit?: (nickname: string) => void;
   onClose?: () => void;
 }
 
 // 익명 방문자가 닉네임을 입력하는 간단한 모달 게이트
-const NicknameGate = ({ onSubmit, onClose }: NicknameGateProps) => {
-  const [value, setValue] = useState('');
-  const [error, setError] = useState<string | null>(null);
+const NicknameGate = ({ onClose }: NicknameGateProps) => {
+  // const [value, setValue] = useState('');
+  // const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-    if (error) setError(null);
-  };
+  // const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   setValue(e.target.value);
+  //   if (error) setError(null);
+  // };
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const trimmed = value.trim();
-    if (trimmed.length < 3 || trimmed.length > 20) {
-      setError('닉네임은 3-20자여야 해요');
-      return;
-    }
-    onSubmit(trimmed);
-  };
+  // const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  //   e.preventDefault();
+  //   const trimmed = value.trim();
+  //   if (trimmed.length < 3 || trimmed.length > 20) {
+  //     setError('닉네임은 3-20자여야 해요');
+  //     return;
+  //   }
+  //   onSubmit(trimmed);
+  // };
 
   const handleGithubLogin = () => {
     signIn('github');

--- a/app/entities/atelier/NicknameGate.tsx
+++ b/app/entities/atelier/NicknameGate.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { signIn } from 'next-auth/react';
 import { FormEvent, useState } from 'react';
+import { FaGithub } from 'react-icons/fa6';
 
 interface NicknameGateProps {
   onSubmit: (nickname: string) => void;
@@ -39,12 +40,22 @@ const NicknameGate = ({ onSubmit, onClose }: NicknameGateProps) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="w-full max-w-sm rounded-2xl border border-border bg-white dark:bg-neutral-900 p-6 shadow-xl">
         <h2 className="text-lg font-semibold text-foreground mb-1">
-          닉네임을 알려주세요
+          로그인이 필요해요
         </h2>
         <p className="text-xs text-weak mb-4">
-          메시지 옆에 표시될 이름이에요.
+          GitHub 계정으로 로그인하면 댓글을 남길 수 있어요.
         </p>
 
+        <button
+          type="button"
+          onClick={handleGithubLogin}
+          className="inline-flex items-center justify-center gap-2 w-full rounded-xl border border-border text-sm text-foreground py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+        >
+          <FaGithub />
+          GitHub으로 로그인
+        </button>
+
+        {/* 닉네임(익명) 로그인 비활성화
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
           <input
             type="text"
@@ -65,22 +76,7 @@ const NicknameGate = ({ onSubmit, onClose }: NicknameGateProps) => {
             확인
           </button>
         </form>
-
-        <div className="my-4 flex items-center gap-2">
-          <div className="h-px flex-1 bg-border" />
-          <span className="text-[10px] uppercase tracking-widest text-weak">
-            또는
-          </span>
-          <div className="h-px flex-1 bg-border" />
-        </div>
-
-        <button
-          type="button"
-          onClick={handleGithubLogin}
-          className="w-full rounded-xl border border-border text-sm text-foreground py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
-        >
-          GitHub으로 로그인
-        </button>
+        */}
 
         {onClose && (
           <button

--- a/app/entities/atelier/ReactionBar.tsx
+++ b/app/entities/atelier/ReactionBar.tsx
@@ -1,4 +1,6 @@
 'use client';
+import Image from 'next/image';
+import { useState } from 'react';
 import { AtelierEmoji, ReactionBucket } from '@/app/types/Atelier';
 
 interface ReactionBarProps {
@@ -6,31 +8,64 @@ interface ReactionBarProps {
   onToggle: (emoji: AtelierEmoji) => void;
 }
 
-// 메시지 아래에 표시되는 반응 칩들
 const ReactionBar = ({ reactions, onToggle }: ReactionBarProps) => {
-  if (!reactions || reactions.length === 0) return null;
+  const [hoveredEmoji, setHoveredEmoji] = useState<string | null>(null);
 
-  const handleClick = (emoji: string) => {
-    onToggle(emoji as AtelierEmoji);
-  };
+  if (!reactions || reactions.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-1 mt-1">
       {reactions.map((r) => (
-        <button
+        <div
           key={r.emoji}
-          type="button"
-          onClick={() => handleClick(r.emoji)}
-          className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors ${
-            r.hasReacted
-              ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
-              : 'border-border text-weak hover:border-brand-primary'
-          }`}
-          aria-label={`${r.emoji} ${r.count}개 반응`}
+          className="relative"
+          onMouseEnter={() => setHoveredEmoji(r.emoji)}
+          onMouseLeave={() => setHoveredEmoji(null)}
         >
-          <span className="text-sm leading-none">{r.emoji}</span>
-          <span className="tabular-nums">{r.count}</span>
-        </button>
+          <button
+            type="button"
+            onClick={() => onToggle(r.emoji as AtelierEmoji)}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors ${
+              r.hasReacted
+                ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                : 'border-border text-weak hover:border-brand-primary'
+            }`}
+            aria-label={`${r.emoji} ${r.count}개 반응`}
+          >
+            <span className="text-sm leading-none">{r.emoji}</span>
+            <span className="tabular-nums">{r.count}</span>
+          </button>
+
+          {hoveredEmoji === r.emoji && r.reactors && r.reactors.length > 0 && (
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 animate-popUp">
+              <div className="bg-background border border-border rounded-xl shadow-lg px-3 py-2 flex flex-col gap-1.5 min-w-max max-w-[200px]">
+                {r.reactors.map((reactor, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    {reactor.avatarUrl ? (
+                      <Image
+                        src={reactor.avatarUrl}
+                        alt={reactor.displayName}
+                        width={16}
+                        height={16}
+                        className="rounded-full shrink-0"
+                        unoptimized
+                      />
+                    ) : (
+                      <div className="w-4 h-4 rounded-full bg-border shrink-0" />
+                    )}
+                    <span className="text-xs text-default truncate">
+                      {reactor.displayName}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              {/* 말풍선 꼬리 */}
+              <div className="flex justify-center">
+                <div className="w-2 h-2 bg-background border-r border-b border-border rotate-45 -mt-1" />
+              </div>
+            </div>
+          )}
+        </div>
       ))}
     </div>
   );

--- a/app/entities/atelier/ThreadPanel.tsx
+++ b/app/entities/atelier/ThreadPanel.tsx
@@ -185,6 +185,7 @@ const ThreadPanel = ({
       <MessageInput
         onSend={handleSend}
         placeholder="답글을 남겨주세요... (Enter)"
+        isAdmin={isAdmin}
       />
 
       {isGateOpen &&

--- a/app/entities/common/DividerWithText.tsx
+++ b/app/entities/common/DividerWithText.tsx
@@ -1,0 +1,20 @@
+interface DividerWithTextProps {
+  text: string;
+  className?: string;
+}
+
+const DividerWithText = ({ text, className = '' }: DividerWithTextProps) => {
+  return (
+    <div
+      className={`flex items-center gap-3 ${className}`}
+      role="separator"
+      aria-label={text}
+    >
+      <div className="h-px flex-1 bg-gray-300" />
+      <span className="shrink-0 text-sm text-gray-500">{text}</span>
+      <div className="h-px flex-1 bg-gray-300" />
+    </div>
+  );
+};
+
+export default DividerWithText;

--- a/app/entities/common/Footer.tsx
+++ b/app/entities/common/Footer.tsx
@@ -1,65 +1,24 @@
 'use client';
-import axios from 'axios';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState, FormEvent } from 'react';
-import useToast from '@/app/hooks/useToast';
+import useSubscribe from '@/app/hooks/useSubscribe';
 
 const HIDDEN_PATHS = ['/atelier'];
 
 const Footer = () => {
   const pathname = usePathname();
-  const toast = useToast();
-  const [nickname, setNickname] = useState('');
-  const [email, setEmail] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
+  const {
+    nickname,
+    email,
+    isLoading,
+    isSubmitted,
+    setNickname,
+    setEmail,
+    handleSubmit,
+    handleReset: handleResubmit,
+  } = useSubscribe();
 
   if (HIDDEN_PATHS.some((p) => pathname.startsWith(p))) return null;
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-
-    if (!nickname.trim() || !email.trim()) {
-      toast.error('닉네임과 이메일을 모두 입력해주세요.');
-      return;
-    }
-
-    if (nickname.trim().length < 2) {
-      toast.error('닉네임은 최소 2자 이상이어야 합니다.');
-      return;
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      toast.error('유효한 이메일 주소를 입력해주세요.');
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const response = await axios.post('/api/subscribe', {
-        email: email.trim(),
-        nickname: nickname.trim(),
-      });
-
-      if (response.data.success) {
-        toast.success(response.data.message || '인증 이메일이 발송되었습니다.');
-        setIsSubmitted(true);
-        setNickname('');
-        setEmail('');
-      }
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        toast.error(error.response.data.error || '구독 신청에 실패했습니다.');
-      } else {
-        toast.error('구독 신청 중 오류가 발생했습니다.');
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   return (
     <footer
@@ -106,7 +65,7 @@ const Footer = () => {
                 이메일을 확인하여 구독을 완료해주세요.
               </p>
               <button
-                onClick={() => setIsSubmitted(false)}
+                onClick={handleResubmit}
                 className={'text-sm text-gray-600 dark:text-gray-400 underline'}
               >
                 다시 입력하기

--- a/app/entities/common/Modal/DeleteModal.tsx
+++ b/app/entities/common/Modal/DeleteModal.tsx
@@ -1,6 +1,6 @@
 'use client';
-import useShortcut from '@/app/hooks/common/useShortcut';
 import Modal from '@/app/entities/common/Modal/Modal';
+import useShortcut from '@/app/hooks/common/useShortcut';
 
 interface DeleteModalProps {
   onCancel: () => void;

--- a/app/entities/common/Modal/DeleteModal.tsx
+++ b/app/entities/common/Modal/DeleteModal.tsx
@@ -1,3 +1,5 @@
+'use client';
+import useShortcut from '@/app/hooks/common/useShortcut';
 import Modal from '@/app/entities/common/Modal/Modal';
 
 interface DeleteModalProps {
@@ -13,6 +15,8 @@ const DeleteModal = ({
   title = '정말 삭제하시겠어요?',
   message = '이 작업은 되돌릴 수 없습니다.',
 }: DeleteModalProps) => {
+  useShortcut(onConfirm, ['Enter'], false);
+
   return (
     <Modal onClose={onCancel}>
       <div className="p-6 flex flex-col gap-5">

--- a/app/entities/common/Modal/DeleteModal.tsx
+++ b/app/entities/common/Modal/DeleteModal.tsx
@@ -1,33 +1,59 @@
-const DeleteModal = (props: {
+import Modal from '@/app/entities/common/Modal/Modal';
+
+interface DeleteModalProps {
   onCancel: () => void;
   onConfirm: () => void;
+  title?: string;
   message?: string;
-}) => {
-  const defaultMessage =
-    '게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다. 게시글이 영구적으로 삭제됩니다.';
+}
+
+const DeleteModal = ({
+  onCancel,
+  onConfirm,
+  title = '정말 삭제하시겠어요?',
+  message = '이 작업은 되돌릴 수 없습니다.',
+}: DeleteModalProps) => {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 text-black">
-        <h2 className="text-xl font-semibold">게시글을 삭제하시겠습니까?</h2>
-        <p className="mt-2 text-gray-600">
-          {props.message ? props.message : defaultMessage}
-        </p>
-        <div className="mt-6 flex justify-end gap-3">
+    <Modal onClose={onCancel}>
+      <div className="p-6 flex flex-col gap-5">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="w-12 h-12 rounded-full bg-red-50 dark:bg-red-950/40 flex items-center justify-center">
+            <svg
+              className="w-6 h-6 text-red-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.8}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-default">{title}</h2>
+            <p className="mt-1 text-sm text-weak">{message}</p>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
           <button
-            onClick={props.onCancel}
-            className="px-4 py-2 text-gray-600 border rounded hover:bg-gray-50"
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 rounded-xl text-sm font-medium border border-border text-weak hover:bg-foreground/50 transition-colors"
           >
             취소
           </button>
           <button
-            onClick={props.onConfirm}
-            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+            onClick={onConfirm}
+            className="flex-1 px-4 py-2 rounded-xl text-sm font-medium bg-red-500 text-white hover:bg-red-600 transition-colors"
           >
             삭제
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/app/entities/common/Modal/Modal.tsx
+++ b/app/entities/common/Modal/Modal.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { ReactNode, useEffect } from 'react';
+
+interface ModalProps {
+  onClose?: () => void;
+  children: ReactNode;
+  className?: string;
+}
+
+const Modal = ({ onClose, children, className = '' }: ModalProps) => {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose?.();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose?.();
+      }}
+    >
+      <div
+        className={`animate-popUp bg-background border border-border rounded-2xl shadow-xl w-full max-w-sm mx-4 ${className}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/app/entities/common/NavBar.tsx
+++ b/app/entities/common/NavBar.tsx
@@ -2,8 +2,10 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { HiOutlineBars3BottomRight } from 'react-icons/hi2';
 import { IoMoonSharp, IoSunnySharp } from 'react-icons/io5';
 import IconButton from '@/app/entities/common/Button/IconButton';
+import NavSidebar from '@/app/entities/common/NavSidebar';
 import Profile from '@/app/entities/common/Profile';
 import useTheme from '@/app/hooks/useTheme';
 
@@ -11,6 +13,7 @@ const TRANSPARENT_PATHS = ['/atelier'];
 
 const NavBar = () => {
   const [isFixed, setIsFixed] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const pathname = usePathname();
 
@@ -18,28 +21,38 @@ const NavBar = () => {
 
   useEffect(() => {
     const handleScroll = () => {
-      const offset = window.scrollY;
-      if (offset > 100) {
-        setIsFixed(true);
-      } else {
-        setIsFixed(false);
-      }
+      setIsFixed(window.scrollY > 100);
     };
 
     window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
+    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const fixedStyle = isTransparent ? 'bg-transparent' : isFixed ? 'bg-white bg-opacity-20' : 'bg-background';
+  useEffect(() => {
+    setIsSidebarOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    document.body.style.overflow = isSidebarOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isSidebarOpen]);
+
+  const handleSidebarOpen = () => setIsSidebarOpen(true);
+  const handleSidebarClose = () => setIsSidebarOpen(false);
+
+  const fixedStyle = isTransparent
+    ? 'bg-transparent'
+    : isFixed
+      ? 'bg-white bg-opacity-20'
+      : 'bg-background';
 
   return (
     <nav>
       <div className={'h-16 w-full'} />
       <div
-        className={`${fixedStyle} fixed h-16 top-0 px-4 w-screen  inline-flex items-center justify-center z-40 backdrop-blur-sm`}
+        className={`${fixedStyle} fixed h-16 top-0 px-4 w-screen inline-flex items-center justify-center z-40 backdrop-blur-sm`}
       >
         <div>
           <Link href={'/'}>
@@ -49,11 +62,7 @@ const NavBar = () => {
             />
           </Link>
         </div>
-        <ul
-          className={
-            'inline-flex max-w-5xl flex-grow justify-end gap-3 items-center'
-          }
-        >
+        <ul className={'inline-flex max-w-5xl flex-grow justify-end gap-3 items-center'}>
           <li>
             <Link href="/posts">Blog</Link>
           </li>
@@ -61,9 +70,12 @@ const NavBar = () => {
             <Link href="/series">Series</Link>
           </li>
           <li>
+            <Link href="/atelier">Atelier</Link>
+          </li>
+          <li className={'hidden sm:block'}>
             <Link href="/tags">Tags</Link>
           </li>
-          <li>
+          <li className={'hidden sm:block'}>
             <Link href="/portfolio">Portfolio</Link>
           </li>
           <li>
@@ -74,8 +86,18 @@ const NavBar = () => {
               aria-label="테마 변경 버튼"
             />
           </li>
+          <li className={'sm:hidden'}>
+            <IconButton
+              onClick={handleSidebarOpen}
+              Icon={HiOutlineBars3BottomRight}
+              size={16}
+              aria-label="메뉴 열기"
+            />
+          </li>
         </ul>
       </div>
+
+      <NavSidebar isOpen={isSidebarOpen} onClose={handleSidebarClose} />
     </nav>
   );
 };

--- a/app/entities/common/NavBar.tsx
+++ b/app/entities/common/NavBar.tsx
@@ -62,14 +62,18 @@ const NavBar = () => {
             />
           </Link>
         </div>
-        <ul className={'inline-flex max-w-5xl flex-grow justify-end gap-3 items-center'}>
-          <li>
+        <ul
+          className={
+            'inline-flex max-w-5xl flex-grow justify-end gap-1.5 sm:gap-3 items-center'
+          }
+        >
+          <li className={'hidden sm:block'}>
             <Link href="/posts">Blog</Link>
           </li>
-          <li>
+          <li className={'hidden sm:block'}>
             <Link href="/series">Series</Link>
           </li>
-          <li>
+          <li className={'hidden sm:block'}>
             <Link href="/atelier">Atelier</Link>
           </li>
           <li className={'hidden sm:block'}>

--- a/app/entities/common/NavSidebar.tsx
+++ b/app/entities/common/NavSidebar.tsx
@@ -1,0 +1,124 @@
+'use client';
+import Link from 'next/link';
+import { IoCloseOutline } from 'react-icons/io5';
+import IconButton from '@/app/entities/common/Button/IconButton';
+import useSubscribe from '@/app/hooks/useSubscribe';
+
+interface NavSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
+  const {
+    nickname,
+    email,
+    isLoading,
+    isSubmitted,
+    setNickname,
+    setEmail,
+    handleSubmit,
+    handleReset,
+  } = useSubscribe();
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+  };
+
+  return (
+    <>
+      {/* 오버레이 */}
+      {isOpen && (
+        <div
+          className={'fixed inset-0 z-50 bg-black bg-opacity-40'}
+          onClick={onClose}
+        />
+      )}
+
+      {/* 사이드바 */}
+      <div
+        className={`fixed top-0 right-0 z-50 flex h-full w-64 flex-col bg-background shadow-xl transition-transform duration-300 sm:hidden ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {/* 닫기 버튼 */}
+        <div className={'flex h-16 items-center justify-end px-4'}>
+          <IconButton
+            onClick={onClose}
+            Icon={IoCloseOutline}
+            size={20}
+            aria-label="메뉴 닫기"
+          />
+        </div>
+
+        {/* 네비게이션 링크 */}
+        <ul className={'flex flex-col gap-6 px-6 py-4 text-lg'}>
+          <li>
+            <Link href="/posts">Blog</Link>
+          </li>
+          <li>
+            <Link href="/series">Series</Link>
+          </li>
+          <li>
+            <Link href="/atelier">Atelier</Link>
+          </li>
+          <li>
+            <Link href="/tags">Tags</Link>
+          </li>
+          <li>
+            <Link href="/portfolio">Portfolio</Link>
+          </li>
+        </ul>
+
+        {/* 구독 폼 */}
+        <div className={'mt-auto border-t border-gray-200 px-6 py-6 dark:border-gray-700'}>
+          <p className={'mb-4 text-sm font-semibold'}>새 글 구독하기</p>
+          {isSubmitted ? (
+            <div className={'flex flex-col gap-2'}>
+              <p className={'text-xs text-green-600 dark:text-green-400'}>
+                인증 이메일이 발송되었습니다!
+              </p>
+              <button
+                onClick={handleReset}
+                className={'text-xs text-gray-500 underline'}
+              >
+                다시 입력하기
+              </button>
+            </div>
+          ) : (
+            <form className={'flex flex-col gap-3'} onSubmit={handleSubmit}>
+              <input
+                className={'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'}
+                placeholder={'닉네임'}
+                value={nickname}
+                onChange={handleNicknameChange}
+                disabled={isLoading}
+              />
+              <input
+                type="email"
+                className={'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'}
+                placeholder={'이메일'}
+                value={email}
+                onChange={handleEmailChange}
+                disabled={isLoading}
+              />
+              <button
+                type="submit"
+                className={'mt-1 rounded-md border border-current py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-50'}
+                disabled={isLoading}
+              >
+                {isLoading ? '처리 중...' : 'Subscribe'}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default NavSidebar;

--- a/app/entities/common/NavSidebar.tsx
+++ b/app/entities/common/NavSidebar.tsx
@@ -56,7 +56,9 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
         </div>
 
         {/* 네비게이션 링크 */}
-        <ul className={'flex flex-col gap-6 px-6 py-4 text-lg'}>
+        <DividerWithText text="Routes" className="text-xs mx-6" />
+
+        <ul className={'flex flex-col gap-6 px-6 py-4 text-lg text-right'}>
           <li>
             <Link href="/posts">Blog</Link>
           </li>
@@ -75,8 +77,8 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
         </ul>
 
         {/* 구독 폼 */}
-        <div className={'mt-auto border-t border-gray-200 px-6 py-6 dark:border-gray-700'}>
-          <p className={'mb-4 text-sm font-semibold'}>새 글 구독하기</p>
+        <DividerWithText text="Subscription" className="text-xs mx-6 mt-12" />
+        <div className={'px-6 py-6 dark:border-gray-700'}>
           {isSubmitted ? (
             <div className={'flex flex-col gap-2'}>
               <p className={'text-xs text-green-600 dark:text-green-400'}>
@@ -92,7 +94,9 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
           ) : (
             <form className={'flex flex-col gap-3'} onSubmit={handleSubmit}>
               <input
-                className={'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'}
+                className={
+                  'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'
+                }
                 placeholder={'닉네임'}
                 value={nickname}
                 onChange={handleNicknameChange}
@@ -100,7 +104,9 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
               />
               <input
                 type="email"
-                className={'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'}
+                className={
+                  'border-b bg-transparent px-2 py-1 text-sm outline-none focus:border-gray-500'
+                }
                 placeholder={'이메일'}
                 value={email}
                 onChange={handleEmailChange}
@@ -108,7 +114,9 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
               />
               <button
                 type="submit"
-                className={'mt-1 rounded-md border border-current py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-50'}
+                className={
+                  'mt-1 rounded-md border border-current py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-50'
+                }
                 disabled={isLoading}
               >
                 {isLoading ? '처리 중...' : 'Subscribe'}
@@ -118,6 +126,25 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
         </div>
       </div>
     </>
+  );
+};
+
+type DividerWithTextProps = {
+  text: string;
+  className?: string;
+};
+
+const DividerWithText = ({ text, className = '' }: DividerWithTextProps) => {
+  return (
+    <div
+      className={`flex items-center gap-3 ${className}`}
+      role="separator"
+      aria-label={text}
+    >
+      <div className="h-px flex-1 bg-gray-300" />
+      <span className="shrink-0 text-sm text-gray-500">{text}</span>
+      <div className="h-px flex-1 bg-gray-300" />
+    </div>
   );
 };
 

--- a/app/entities/common/NavSidebar.tsx
+++ b/app/entities/common/NavSidebar.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { IoCloseOutline } from 'react-icons/io5';
 import IconButton from '@/app/entities/common/Button/IconButton';
+import DividerWithText from '@/app/entities/common/DividerWithText';
 import useSubscribe from '@/app/hooks/useSubscribe';
 
 interface NavSidebarProps {
@@ -126,25 +127,6 @@ const NavSidebar = ({ isOpen, onClose }: NavSidebarProps) => {
         </div>
       </div>
     </>
-  );
-};
-
-type DividerWithTextProps = {
-  text: string;
-  className?: string;
-};
-
-const DividerWithText = ({ text, className = '' }: DividerWithTextProps) => {
-  return (
-    <div
-      className={`flex items-center gap-3 ${className}`}
-      role="separator"
-      aria-label={text}
-    >
-      <div className="h-px flex-1 bg-gray-300" />
-      <span className="shrink-0 text-sm text-gray-500">{text}</span>
-      <div className="h-px flex-1 bg-gray-300" />
-    </div>
   );
 };
 

--- a/app/entities/common/Toast/Toast.tsx
+++ b/app/entities/common/Toast/Toast.tsx
@@ -23,17 +23,19 @@ const Toast = ({ message, title, type, removeToast }: ToastProps) => {
           transform transition-all duration-300 ease-out animate-slideUp
           bg-gray-200/90 text-black px-3 py-2 rounded-lg flex items-center gap-3
           backdrop-blur-sm w-full max-w-md origin-center cursor-pointer
-          hover:bg-gray-300/90 hover:shadow-lg
+          hover:bg-gray-300/90 
+          border border-gray-400/50
+          shadow-neutral-500/50 shadow-lg hover:shadow-lg
         `}
     >
       <div className={`flex items-center justify-center rounded-full p-0.5`}>
         {iconMap[type]}
       </div>
       <div className="flex-1 min-w-0">
-        {title && (
-          <p className="text font-semibold text-sm">{title}</p>
-        )}
-        <p className={`text whitespace-pre-line ${title ? 'text-xs text-gray-600 mt-0.5' : 'line-clamp-1'}`}>
+        {title && <p className="text font-semibold text-sm">{title}</p>}
+        <p
+          className={`text whitespace-pre-line ${title ? 'text-xs text-gray-600 mt-0.5' : 'line-clamp-1'}`}
+        >
           {message}
         </p>
       </div>

--- a/app/entities/common/Toast/ToastProvider.tsx
+++ b/app/entities/common/Toast/ToastProvider.tsx
@@ -1,35 +1,56 @@
 'use client';
+import { useEffect, useRef, useState } from 'react';
 import Toast from '@/app/entities/common/Toast/Toast';
 import useToastStore from '@/app/stores/useToastStore';
 
-interface Toast {
-  id: number;
-  message: string;
-  title?: string;
-  type: 'success' | 'error' | 'info';
-}
+const MAX_VISIBLE = 3;
+const PEEK_OFFSET = 14;
+const SCALE_STEP = 0.06;
 
 const ToastProvider = () => {
   const { toasts, removeToast } = useToastStore();
+  const [frontHeight, setFrontHeight] = useState(64);
+  const frontRef = useRef<HTMLDivElement>(null);
 
-  const reversedToasts = [...toasts].reverse();
+  const visibleToasts = toasts.slice(0, MAX_VISIBLE);
+
+  useEffect(() => {
+    const el = frontRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => setFrontHeight(el.offsetHeight));
+    ro.observe(el);
+    setFrontHeight(el.offsetHeight);
+    return () => ro.disconnect();
+  }, [visibleToasts[0]?.id]);
+
+  if (visibleToasts.length === 0) return null;
+
+  const containerHeight = frontHeight + (visibleToasts.length - 1) * PEEK_OFFSET;
+
   return (
     <div
-      className={
-        'fixed bottom-6 left-1/2 transform -translate-x-1/2 flex flex-col gap-4  z-50 w-[90%] max-w-md'
-      }
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 w-[90%] max-w-md"
+      style={{ height: containerHeight }}
     >
-      {reversedToasts.map((toast: Toast) => {
-        return (
+      {visibleToasts.map((toast, index) => (
+        <div
+          key={toast.id}
+          ref={index === 0 ? frontRef : undefined}
+          className="absolute bottom-0 left-0 right-0 transition-all duration-300 origin-bottom"
+          style={{
+            transform: `translateY(${-index * PEEK_OFFSET}px) scale(${1 - index * SCALE_STEP})`,
+            opacity: 1 - index * 0.12,
+            zIndex: MAX_VISIBLE - index,
+          }}
+        >
           <Toast
-            key={toast.id}
             removeToast={() => removeToast(toast.id)}
             message={toast.message}
             title={toast.title}
             type={toast.type}
           />
-        );
-      })}
+        </div>
+      ))}
     </div>
   );
 };

--- a/app/hooks/atelier/useAtelierMessages.ts
+++ b/app/hooks/atelier/useAtelierMessages.ts
@@ -1,6 +1,7 @@
 'use client';
 import axios from 'axios';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { skipEntryAnimSet } from '@/app/entities/atelier/MessageBubble';
 import {
   AtelierMessage,
   GetMessagesResponse,
@@ -165,6 +166,7 @@ const useAtelierMessages = (
   // 서버 응답으로 교체
   const replaceOptimistic = useCallback(
     (tempId: string, real: AtelierMessage) => {
+      skipEntryAnimSet.add(real._id);
       setMessageMap((prev) => {
         const next = new Map(prev);
         next.delete(tempId);

--- a/app/hooks/atelier/useAtelierMessages.ts
+++ b/app/hooks/atelier/useAtelierMessages.ts
@@ -23,6 +23,8 @@ interface UseAtelierMessagesReturn {
   removeOptimistic: (tempId: string) => void;
   updateMessage: (id: string, patch: Partial<AtelierMessage>) => void;
   removeMessage: (id: string) => void;
+  getSnapshot: (id: string) => AtelierMessage | undefined;
+  restoreMessage: (msg: AtelierMessage) => void;
   refresh: () => Promise<void>;
 }
 
@@ -205,6 +207,22 @@ const useAtelierMessages = (
     });
   }, []);
 
+  const getSnapshot = useCallback(
+    (id: string): AtelierMessage | undefined => {
+      return messageMap.get(id);
+    },
+    [messageMap]
+  );
+
+  const restoreMessage = useCallback((msg: AtelierMessage) => {
+    setMessageMap((prev) => {
+      const next = new Map(prev);
+      next.set(msg._id, msg);
+      oldestCursorRef.current = computeOldestCursor(next);
+      return next;
+    });
+  }, []);
+
   const messages = useMemo(() => toSortedArray(messageMap), [messageMap]);
 
   return {
@@ -219,6 +237,8 @@ const useAtelierMessages = (
     removeOptimistic,
     updateMessage,
     removeMessage,
+    getSnapshot,
+    restoreMessage,
     refresh: fetchInitial,
   };
 };

--- a/app/hooks/atelier/useAtelierMutations.ts
+++ b/app/hooks/atelier/useAtelierMutations.ts
@@ -24,6 +24,8 @@ interface MessagesApi {
   removeOptimistic: (tempId: string) => void;
   updateMessage: (id: string, patch: Partial<AtelierMessage>) => void;
   removeMessage: (id: string) => void;
+  getSnapshot: (id: string) => AtelierMessage | undefined;
+  restoreMessage: (msg: AtelierMessage) => void;
 }
 
 interface UseAtelierMutationsOptions {
@@ -155,16 +157,18 @@ const useAtelierMutations = (
     [author.fingerprint, messagesApi, toast]
   );
 
-  // 관리자 삭제
+  // 관리자 삭제 — 낙관적 업데이트 후 실패 시 복구
   const deleteMessage = useCallback(
     async (messageId: string) => {
+      const snapshot = messagesApi.getSnapshot(messageId);
+      messagesApi.removeMessage(messageId);
       try {
         await axios.delete(`/api/atelier/messages/${messageId}`, {
           headers: fingerprintHeaders(author.fingerprint),
         });
-        messagesApi.removeMessage(messageId);
         toast.success('메시지를 삭제했어요.');
       } catch (err) {
+        if (snapshot) messagesApi.restoreMessage(snapshot);
         if (axios.isAxiosError(err) && err.response?.status === 429) {
           const retryAfter = err.response.data?.retryAfter ?? 60;
           toast.error(`${retryAfter}초 후에 다시 시도해주세요`);

--- a/app/hooks/atelier/useAtelierMutations.ts
+++ b/app/hooks/atelier/useAtelierMutations.ts
@@ -122,7 +122,12 @@ const useAtelierMutations = (
       try {
         const { data } = await axios.post<PostReactionResponse>(
           `/api/atelier/messages/${messageId}/reaction`,
-          { emoji },
+          {
+            emoji,
+            nickname: author.nickname ?? '익명',
+            avatarUrl: author.avatarUrl,
+            githubId: author.githubId,
+          },
           { headers: fingerprintHeaders(author.fingerprint) }
         );
         messagesApi.updateMessage(messageId, { reactions: data.reactions });
@@ -130,7 +135,7 @@ const useAtelierMutations = (
         toast.error('반응을 남기지 못했어요.');
       }
     },
-    [author.fingerprint, messagesApi, toast]
+    [author, messagesApi, toast]
   );
 
   // 메시지 수정

--- a/app/hooks/useSubscribe.ts
+++ b/app/hooks/useSubscribe.ts
@@ -1,0 +1,77 @@
+import axios from 'axios';
+import { FormEvent, useState } from 'react';
+import useToast from '@/app/hooks/useToast';
+
+interface UseSubscribeReturn {
+  nickname: string;
+  email: string;
+  isLoading: boolean;
+  isSubmitted: boolean;
+  setNickname: (value: string) => void;
+  setEmail: (value: string) => void;
+  handleSubmit: (e: FormEvent) => Promise<void>;
+  handleReset: () => void;
+}
+
+const useSubscribe = (): UseSubscribeReturn => {
+  const [nickname, setNickname] = useState('');
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const toast = useToast();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!nickname.trim() || !email.trim()) {
+      toast.error('닉네임과 이메일을 모두 입력해주세요.');
+      return;
+    }
+    if (nickname.trim().length < 2) {
+      toast.error('닉네임은 최소 2자 이상이어야 합니다.');
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      toast.error('유효한 이메일 주소를 입력해주세요.');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await axios.post('/api/subscribe', {
+        email: email.trim(),
+        nickname: nickname.trim(),
+      });
+      if (response.data.success) {
+        toast.success(response.data.message || '인증 이메일이 발송되었습니다.');
+        setIsSubmitted(true);
+        setNickname('');
+        setEmail('');
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        toast.error(error.response.data.error || '구독 신청에 실패했습니다.');
+      } else {
+        toast.error('구독 신청 중 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleReset = () => setIsSubmitted(false);
+
+  return {
+    nickname,
+    email,
+    isLoading,
+    isSubmitted,
+    setNickname,
+    setEmail,
+    handleSubmit,
+    handleReset,
+  };
+};
+
+export default useSubscribe;

--- a/app/lib/atelierSerialize.ts
+++ b/app/lib/atelierSerialize.ts
@@ -1,7 +1,7 @@
 // 아틀리에 메시지 직렬화 유틸
 // - lean() 결과를 공용 타입 AtelierMessage 로 변환
 // - fingerprints 는 프라이버시상 제거하고 hasReacted 로 대체
-import { AtelierMessage, ReactionBucket } from '@/app/types/Atelier';
+import { AtelierMessage, ReactionBucket, ReactorInfo } from '@/app/types/Atelier';
 
 export interface LeanAtelierMessage {
   _id: { toString(): string };
@@ -19,6 +19,7 @@ export interface LeanAtelierMessage {
     emoji: string;
     fingerprints?: string[];
     count: number;
+    reactors?: { fingerprint: string; nickname: string; avatarUrl?: string; githubId?: string }[];
   }[];
   isPublic: boolean;
   isDeleted: boolean;
@@ -31,14 +32,26 @@ export const serializeAtelierMessage = (
   raw: LeanAtelierMessage,
   viewerFingerprint: string | null
 ): AtelierMessage => {
-  const reactions: ReactionBucket[] = (raw.reactions ?? []).map((bucket) => ({
-    emoji: bucket.emoji,
-    count: bucket.count,
-    hasReacted:
-      !!viewerFingerprint &&
-      Array.isArray(bucket.fingerprints) &&
-      bucket.fingerprints.includes(viewerFingerprint),
-  }));
+  // 익명 반응자에게 순서 기반 번호 부여
+  let anonCounter = 0;
+  const reactions: ReactionBucket[] = (raw.reactions ?? []).map((bucket) => {
+    const reactors: ReactorInfo[] = (bucket.reactors ?? []).map((r) => {
+      if (r.githubId) {
+        return { displayName: r.nickname, avatarUrl: r.avatarUrl };
+      }
+      anonCounter += 1;
+      return { displayName: `익명${anonCounter}` };
+    });
+    return {
+      emoji: bucket.emoji,
+      count: bucket.count,
+      hasReacted:
+        !!viewerFingerprint &&
+        Array.isArray(bucket.fingerprints) &&
+        bucket.fingerprints.includes(viewerFingerprint),
+      reactors,
+    };
+  });
 
   return {
     _id: raw._id.toString(),

--- a/app/lib/rateLimit.ts
+++ b/app/lib/rateLimit.ts
@@ -5,7 +5,7 @@ type RateLimitEntry = {
 
 const rateLimitMap = new Map<string, RateLimitEntry>();
 
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1분
+const RATE_LIMIT_WINDOW_MS = 15 * 1000; // 15초
 const MAX_REQUESTS = 3;
 
 export function checkRateLimit(identifier: string): {

--- a/app/models/AtelierMessage.ts
+++ b/app/models/AtelierMessage.ts
@@ -8,10 +8,23 @@ import { Schema, model, models } from 'mongoose';
 const reactionSchema = new Schema(
   {
     emoji: { type: String, required: true },
-    // 누가 눌렀는지 식별용 fingerprint 목록 (중복 방지)
     fingerprints: { type: [String], default: [] },
-    // fingerprints.length 캐싱
     count: { type: Number, default: 0 },
+    // 반응자 정보 (툴팁용)
+    reactors: {
+      type: [
+        new Schema(
+          {
+            fingerprint: { type: String, required: true },
+            nickname: { type: String, required: true },
+            avatarUrl: { type: String },
+            githubId: { type: String },
+          },
+          { _id: false }
+        ),
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );

--- a/app/types/Atelier.ts
+++ b/app/types/Atelier.ts
@@ -15,14 +15,19 @@ export interface AtelierAuthor {
   fingerprint?: string;
 }
 
+// 이모지 반응자 정보 (툴팁용, 익명은 displayName만)
+export interface ReactorInfo {
+  displayName: string;
+  avatarUrl?: string;
+}
+
 // 이모지 반응 버킷
 export interface ReactionBucket {
   emoji: string;
   count: number;
-  // 서버가 응답할 때는 fingerprints 생략 가능 (프라이버시),
-  // 내가 눌렀는지 여부만 hasReacted 로 내려줄 수 있음
   fingerprints?: string[];
   hasReacted?: boolean;
+  reactors?: ReactorInfo[];
 }
 
 // 단일 메시지

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -164,6 +164,33 @@ const config: Config = {
             opacity: '0',
           },
         },
+        bubblePop: {
+          '0%': {
+            transform: 'scale(1)',
+            opacity: '1',
+            filter: 'blur(0px) brightness(1)',
+          },
+          '55%': {
+            transform: 'scale(1.08)',
+            opacity: '1',
+            filter: 'blur(0px) brightness(1)',
+          },
+          '68%': {
+            transform: 'scale(1.16)',
+            opacity: '0.9',
+            filter: 'blur(0px) brightness(1.6)',
+          },
+          '80%': {
+            transform: 'scale(1.9)',
+            opacity: '0.15',
+            filter: 'blur(5px) brightness(1)',
+          },
+          '100%': {
+            transform: 'scale(2.4)',
+            opacity: '0',
+            filter: 'blur(10px)',
+          },
+        },
       },
       animation: {
         blink: 'blink 1s ease-in-out infinite',
@@ -177,6 +204,7 @@ const config: Config = {
         bubbleInLeft:
           'bubbleInLeft 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) both',
         atelierIn: 'atelierIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) both',
+        bubblePop: 'bubblePop 0.5s ease-in forwards',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
## 변경 사항
Atelier 채팅 기능의 UI/UX를 전반적으로 개선하고 공통 컴포넌트를 분리


1. 
<img width="1204" height="594" alt="image" src="https://github.com/user-attachments/assets/65d1ea35-9f7f-49fd-b341-a9265e18d527" />

2.
<img width="1256" height="1228" alt="image" src="https://github.com/user-attachments/assets/a31bbb15-8d76-4b2f-994e-3c8f1284f21a" />


주요 변경 내용:
- 텍스트 글자 수 제한
- Github 로그인 제한
- 마크다운 미리보기 
- 링크 새창으로 열기 적용
- 429 Limit 15초 제한으로 축소
- 댓글 삭제 낙관적UI 업데이트 및 애니메이션 추가
- 모달 디자인 개선
- Toast 스택 방식으로 쌓이도록 개선
- 이모지툴바 열리는 방식 변경
- Navbar 사이드바 추가

## 변경 이유

채팅 피드, 메시지 액션, 입력창 등 Atelier 관련 컴포넌트들이 기능이 추가되면서 단일 파일에 로직이 집중. 실시간 구독 로직 중복, 모달 컴포넌트 미공통화, 이모지 피커의 Portal 위치 계산 버그 등 유지보수 이슈를 해결하고, 모바일 반응형 내비게이션 및 Toast 스택 등 UX를 개선하기 위해 리팩토링을 진행